### PR TITLE
removing referench to the solo script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,8 +8,6 @@ nginx_version=$(./bin/nginx-$STACK -V 2>&1 | head -1 | awk '{ print $NF }')
 echo "-----> nginx-buildpack: Installed ${nginx_version} to app/bin"
 cp bin/start-nginx "$1/bin/"
 echo '-----> nginx-buildpack: Added start-nginx to app/bin'
-cp bin/start-nginx-solo "$1/bin/"
-echo '-----> nginx-buildpack: Added start-nginx-solo to app/bin'
 
 mkdir -p "$1/config"
 


### PR DESCRIPTION
Since I removed the `solo` script, I need to remove the reference to said script in the `compile` script. To be clear, we actually run in what they call 'solo' mode, but since our current `kraken` Procfile references `start-nginx`, our transition to this build pack will be smoother if keep the `start-nginx` script as the initialization script.