### PR TITLE
adding folders for config files

### DIFF
--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -7,6 +7,12 @@ mkfifo $psmgr
 #Evaluate config to get $PORT and other variables that may be set and used.
 cd config
 shopt -s nullglob
+for conf_file in **/*.erb
+do
+  target=$(basename ${conf_file%.*})
+  erb $conf_file > $target
+done
+
 for conf_file in *.erb
 do
   target=${conf_file%.*}


### PR DESCRIPTION
Flip side of https://github.com/Americastestkitchen/kraken/pull/403

This is the code that is executed on Heroku when we build `kraken`. This grabs the files in sub-folders, runs them through `erb` and places them all in the top-level config directory. Same as the `kraken` branch (which does that for local dev).